### PR TITLE
Fstrim fix

### DIFF
--- a/files/fstrim_cron
+++ b/files/fstrim_cron
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH="$PATH:/sbin:/usr/sbin"
+
 SLEEP="${1:-0}"
 if [ "$SLEEP" != "0" ];then
   RANDOM_SLEEP=$(( ( $RANDOM % $SLEEP )  + 1 ))


### PR DESCRIPTION
Add /sbin and /usr/sbin to PATH for fstrim_cron script so fstrim can actually be run.